### PR TITLE
Remove misleading categories from .shed.yml

### DIFF
--- a/.shed.yml
+++ b/.shed.yml
@@ -1,6 +1,4 @@
 categories:  # see https://toolshed.g2.bx.psu.edu/repositories_by_category 
-- Data Source
-- Imaging
 - Digital Humanities
 description: Tool to check multimedia files if they are corrupt or duplicated
 long_description: |


### PR DESCRIPTION
The categories in the toolshed are misleading, because they often are part of another domain. For example: "Quality Control" is part of genomics.